### PR TITLE
Release 2.0.154

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,8 +20,8 @@
    {io.github.clojure/tools.build       {:mvn/version "0.9.6"}
     jansi-clj/jansi-clj                 {:mvn/version "1.0.2"}   ; Note: this version has a major bug in the cursor positioning fns (which tools-licenses doesn't use)
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.194"}
-    com.github.pmonks/asf-cat           {:mvn/version "2.0.98"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.197"}
+    com.github.pmonks/asf-cat           {:mvn/version "2.0.102"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.142"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr            {:mvn/version "RELEASE"}


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.154. See commit log for details of what's included in this release.