### PR TITLE
Release 2.0.167

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Optionally, you may also wish to configure logging for your `build` alias, since
        :ns-default your.build.ns}
 ```
 
-Then add this `log4j2.xml` in the root directory of your project (or another directory, which would then need to be added to the `:paths` of your build alias):
+Then add this `log4j2.xml` file in the root directory of your project (or another directory, which would then need to be added to the `:paths` of your build alias):
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -125,7 +125,7 @@ Then add this `log4j2.xml` in the root directory of your project (or another dir
 
 Example summary output:
 
-![Example output from licenses task, summary sub-task](demo-licenses-summary.png)
+<img alt="Example output from licenses task, summary sub-task" src="demo-licenses-summary.png" width="75%"/>
 
 Other invocation possibilities:
 * `clj -T:build licenses :output :summary` - the default (see above)
@@ -133,7 +133,7 @@ Other invocation possibilities:
 * `clj -T:build licenses :output :edn` - detailed per-dependency license information in EDN format
 * `clj -T:build licenses :output :explain :dep <dep symbol>` - an explanation of how the tool arrived at the given license(s) for a single dep (expressed as a tools.dep symbol). For example:
 
-![Example output from licenses task, explain sub-task](demo-licenses-explain.png)
+<img alt="Example output from licenses task, explain sub-task" src="demo-licenses-explain.png" width="75%"/>
 
 If you see `Unidentified (<some text>)` licenses in the output, **[please raise an issue here](https://github.com/pmonks/lice-comb/issues/new?assignees=pmonks&labels=unknown+licenses&template=Unknown_licenses.md)**.
 
@@ -141,7 +141,7 @@ If you see `Unidentified (<some text>)` licenses in the output, **[please raise 
 
 Example summary output:
 
-![Example output from check-asf-policy task](demo-check-asf-policy.png)
+<img alt="Example output from check-asf-policy task, summary sub-task" src="demo-check-asf-policy.png" width="75%"/>
 
 Other invocation possibilities:
 * `clj -T:build check-asf-policy :output :summary` - the default (see above)

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
     jansi-clj/jansi-clj                 {:mvn/version "1.0.2"}   ; Note: this version has a major bug in the cursor positioning fns (which tools-licenses doesn't use)
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
     com.github.pmonks/lice-comb         {:mvn/version "2.0.208"}
-    com.github.pmonks/asf-cat           {:mvn/version "2.0.106"}
+    com.github.pmonks/asf-cat           {:mvn/version "2.0.108"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.142"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr            {:mvn/version "RELEASE"}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
    {io.github.clojure/tools.build       {:mvn/version "0.9.6"}
     jansi-clj/jansi-clj                 {:mvn/version "1.0.2"}   ; Note: this version has a major bug in the cursor positioning fns (which tools-licenses doesn't use)
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.206"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.208"}
     com.github.pmonks/asf-cat           {:mvn/version "2.0.106"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.142"}}
  :aliases


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.167. See commit log for details of what's included in this release.