### PR TITLE
Release 2.0.177

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
    {io.github.clojure/tools.build       {:mvn/version "0.9.6"}
     jansi-clj/jansi-clj                 {:mvn/version "1.0.2"}   ; Note: this version has a major bug in the cursor positioning fns (which tools-licenses doesn't use)
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.219"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.223"}
     com.github.pmonks/asf-cat           {:mvn/version "2.0.108"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.142"}}
  :aliases


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.177. See commit log for details of what's included in this release.