### PR TITLE
Release 2.0.182

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0    # Make sure we get the full history, or else the version number gets screwed up
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0    # Make sure we get the full history, or else the version number gets screwed up
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/deps.edn
+++ b/deps.edn
@@ -18,9 +18,9 @@
 
 {:deps
    {io.github.clojure/tools.build       {:mvn/version "0.9.6"}
-    jansi-clj/jansi-clj                 {:mvn/version "1.0.2"}   ; Note: this version has a major bug in the cursor positioning fns (which tools-licenses doesn't use)
+    jansi-clj/jansi-clj                 {:mvn/version "1.0.3"}
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.223"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.240"}
     com.github.pmonks/asf-cat           {:mvn/version "2.0.108"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.142"}}
  :aliases


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.182. See commit log for details of what's included in this release.