### PR TITLE
Release 2.0.206

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In contrast, `tools-licenses` leverages the [`lice-comb` library](https://github
 
 ## Why not [`scarletcomply/license-finder`](https://github.com/scarletcomply/license-finder)?
 
-* It doesnt canonicalise license information to SPDX License Expressons (it leaves canonicalisation, a fairly difficult problem, to the caller).
+* It doesnt canonicalise license information to SPDX License Expressions (it leaves canonicalisation, a fairly difficult problem, to the caller).
 
 ## I use Leiningen - is something like `tools-licenses` available?
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ This tool uses the [`lice-comb` library](https://github.com/pmonks/lice-comb), w
   * silently ignoring projects that lack a `pom.xml` file (or have one that doesn't contain licensing information) may lull users into a false sense of security vis-a-vis license compliance
   * [Clojars only recently started mandating license information in the POM files it hosts](https://github.com/clojars/clojars-web/issues/873), and as of mid-2023 around 1/3 of all projects deployed hosted there do not include any licensing information in their POM files
 * It's coupled to tools.deps and cannot easily be consumed as an independent library. It's also dependent on tools.deps state management (e.g. requires POM files to be downloaded locally).
-* It doesn't canonicalise license information to SPDX License Expressions (it leaves canonicalisation, a fairly difficult problem, to the caller).
+* It doesn't canonicalise license information to SPDX License Expressions, or even (in some cases) SPDX License Identifiers.
+* It only reports the first license for multi-licensed artifacts.
 
 In contrast, `tools-licenses` leverages the [`lice-comb` library](https://github.com/pmonks/lice-comb), a build-tool-agnostic library that takes a more comprehensive approach to license detection.
 
 ## Why not [`scarletcomply/license-finder`](https://github.com/scarletcomply/license-finder)?
 
-* It doesnt canonicalise license information to SPDX License Expressions (it leaves canonicalisation, a fairly difficult problem, to the caller).
+* It doesn't canonicalise license information to SPDX License Expressions, or even (in some cases) SPDX License Identifiers.
+* It only reports the first license for multi-licensed artifacts.
 
 ## I use Leiningen - is something like `tools-licenses` available?
 

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
    {jansi-clj/jansi-clj                 {:mvn/version "1.0.3"}
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
     com.github.pmonks/lice-comb         {:mvn/version "2.0.270"}
-    com.github.pmonks/asf-cat           {:mvn/version "2.0.125"}
+    com.github.pmonks/asf-cat           {:mvn/version "2.0.127"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.151"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr            {:mvn/version "RELEASE"}

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
 {:deps
    {jansi-clj/jansi-clj                 {:mvn/version "1.0.3"}
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.264"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.270"}
     com.github.pmonks/asf-cat           {:mvn/version "2.0.125"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.151"}}
  :aliases


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.206. See commit log for details of what's included in this release.