### PR TITLE
Release 2.0.219

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,8 +19,8 @@
 {:deps
    {jansi-clj/jansi-clj                 {:mvn/version "1.0.3"}
     com.github.pmonks/clj-wcwidth       {:mvn/version "1.0.85"}
-    com.github.pmonks/lice-comb         {:mvn/version "2.0.279"}
-    com.github.pmonks/asf-cat           {:mvn/version "2.0.131"}
+    com.github.pmonks/lice-comb         {:mvn/version "2.0.284"}
+    com.github.pmonks/asf-cat           {:mvn/version "2.0.133"}
     com.github.pmonks/tools-convenience {:mvn/version "1.0.151"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr            {:mvn/version "RELEASE"}


### PR DESCRIPTION
com.github.pmonks/tools-licenses release 2.0.219. See commit log for details of what's included in this release.